### PR TITLE
Fix Notion sync daemon

### DIFF
--- a/notion_sync_daemon.py
+++ b/notion_sync_daemon.py
@@ -1,10 +1,12 @@
 import schedule
 import time
-from notion_embedder import embed_huddles
+"""Background daemon to periodically sync Notion huddles into Qdrant."""
+
+from notion_embedder import embed_huddles_qdrant
 
 def job():
     print("🧠 Syncing huddles from Notion...")
-    embed_huddles()
+    embed_huddles_qdrant()
 
 schedule.every(10).minutes.do(job)
 


### PR DESCRIPTION
## Summary
- update `notion_sync_daemon` to import and use the current embedding function

## Testing
- `python - <<'EOF'
import pathlib, py_compile
for p in pathlib.Path('.').rglob('*.py'):
    py_compile.compile(str(p))
print('All compiled')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684118e264b4832ead2744d31c4fce1c