### PR TITLE
Fix Notion sync daemon

### DIFF
--- a/memory_vector.py
+++ b/memory_vector.py
@@ -53,35 +53,23 @@ def embed_and_store_interaction(screenshot_text, user_draft, ai_suggested, user_
     )
 
 def retrieve_similar_examples(screenshot_text, user_draft, top_k=3, score_threshold=0.7):
-    import os
-    from qdrant_client import QdrantClient
-    from memory_vector import get_embedding
-
-    COLLECTION_NAME = "huddle_memory"
-
-    client = QdrantClient(
-        url=os.getenv("QDRANT_URL"),
-        api_key=os.getenv("QDRANT_API_KEY")
-    )
 
     query = f"{screenshot_text}\n\n{user_draft}"
     vector = get_embedding(query)
 
-    search_result = client.search(
+    search_result = qdrant.search(
         collection_name=COLLECTION_NAME,
         query_vector=vector,
         limit=top_k,
         with_payload=True,
-        with_vectors=False
+        with_vectors=False,
+        score_threshold=score_threshold,
     )
 
     examples = []
     for point in search_result:
         payload = point.payload or {}
         score = point.score
-
-        if score < score_threshold:
-            continue
 
         examples.append({
             "screenshot_text": payload.get("screenshot", ""),

--- a/notion_sync_daemon.py
+++ b/notion_sync_daemon.py
@@ -1,10 +1,12 @@
 import schedule
 import time
-from notion_embedder import embed_huddles
+"""Background daemon to periodically sync Notion huddles into Qdrant."""
+
+from notion_embedder import embed_huddles_qdrant
 
 def job():
     print("🧠 Syncing huddles from Notion...")
-    embed_huddles()
+    embed_huddles_qdrant()
 
 schedule.every(10).minutes.do(job)
 


### PR DESCRIPTION
## Summary
- update `notion_sync_daemon` to import and use the current embedding function
- remove redundant Qdrant client creation in `retrieve_similar_examples`
- filter by `score_threshold` directly in search

## Testing
- `python - <<'EOF'
import pathlib, py_compile
for p in pathlib.Path('.').rglob('*.py'):
    py_compile.compile(str(p))
print('All compiled')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684118e264b4832ead2744d31c4fce1c