### PR TITLE
Refactor to external CSS

### DIFF
--- a/app copy.py
+++ b/app copy.py
@@ -36,50 +36,22 @@ VECTOR_SIZE = 1536
 st.set_page_config(page_title="Huddle Assistant", layout="centered")
 
 # ---- HEADER ----
-st.markdown("""
-    <div style="
-        background: linear-gradient(135deg, #8a3ffc, #b88cff);
-        padding: 20px; border-radius: 12px; color: white;
-        text-align: center; font-family: 'Segoe UI', sans-serif;
-        margin-bottom: 24px;">
-        <h2 style="margin: 0;">🤝 Huddle Assistant</h2>
-        <p style="margin: 4px 0 0 0; font-size: 14px;">
-            Lead confident convos on the go
-        </p>
+with open("styles.css") as f:
+    st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
+
+st.markdown(
+    """
+    <div class="header-container">
+        <h2>🤝 Huddle Assistant</h2>
+        <p>Lead confident convos on the go</p>
     </div>
-""", unsafe_allow_html=True)
+    """,
+    unsafe_allow_html=True,
+)
 
 # ---- Session State Initialization ----
 if "uploader_key" not in st.session_state:
     st.session_state.uploader_key = 0
-
-# ---- CSS for Spacing & Tabs ----
-st.markdown("""
-<style>
-section.main > div {padding-top: 0rem !important; padding-bottom: 0rem !important;}
-.css-1kyxreq, .stSelectbox, .stMarkdown, .stSubheader {margin-bottom: 0.5rem !important; margin-top: 0.5rem !important;}
-.st-expander {margin-top: -0.5rem !important;}
-.stTabs [data-baseweb="tab-list"] {
-    gap: 0.5rem !important; background: none !important;
-    border-bottom: 2px solid #27273a !important; margin-bottom: 0px !important;
-    padding: 0 6vw !important; justify-content: left;
-}
-.stTabs [data-baseweb="tab"] {
-    color: #8a3ffc !important; font-weight: 600; font-size: 1.05rem;
-    padding: 8px 16px !important; border-radius: 16px 16px 0 0;
-    background: none !important; transition: background 0.18s;
-    margin-bottom: -2px;
-}
-.stTabs [aria-selected="true"] {
-    background: linear-gradient(90deg, #8a3ffc 65%, #b88cff 100%) !important;
-    color: #fff !important; border-bottom: 2.5px solid #8a3ffc !important;
-    box-shadow: 0 2px 8px rgba(138,63,252,0.08);
-}
-.stTabs [aria-selected="false"]:hover {
-    background: #ede9fe !important; color: #5d27c1 !important;
-}
-</style>
-""", unsafe_allow_html=True)
 
 # ---- Sidebar Settings ----
 with st.sidebar.expander("🛠️ Quality Save Settings", expanded=False):
@@ -167,24 +139,15 @@ def render_polished_card(label, text_content, auto_copy=False):
     """
 
     full_html = f"""
-    <div style="
-        max-width: 100vw; background-color: #1e1e1e; border: 1px solid #333;
-        border-radius: 12px; box-shadow: 0 20px 6px rgba(0,0,0,0.1); padding: 16px; margin: 0;
-        font-family: 'Segoe UI', sans-serif; font-size: 16px; color: #f0f0f0;">
-        <h4 style="margin: 0 0 12px 0;">{label}</h4>
-        <div id="textDisplay-{unique_id}" style="
-            background: #2a2a2a; border-radius: 8px; padding: 12px;
-            white-space: normal; word-wrap: break-word;
-            line-height: 1.6; border: 1px solid #444;
-            overflow-y: auto; height: {fixed_height}px;">
+    <div class="copy-card">
+        <h4>{label}</h4>
+        <div id="textDisplay-{unique_id}" class="text-display" style="height: {fixed_height}px;">
             {html_formatted_text_for_display}
         </div>
-        <button onclick="{copy_button_onclick_js}" style="
-            margin-top: 12px; padding: 6px 12px; background-color: #22c55e;
-            color: white; border: none; border-radius: 6px; font-weight: 500; cursor: pointer;">
+        <button onclick="{copy_button_onclick_js}" class="copy-button-green">
             📋 Copy to Clipboard
         </button>
-        <span id="copyAlert-{unique_id}" style="display: none; margin-left: 10px; color: #22c55e; font-weight: 500;">
+        <span id="copyAlert-{unique_id}" class="copy-alert-green">
             ✅ Copied!
         </span>
         {auto_copy_script}

--- a/app.py
+++ b/app.py
@@ -43,50 +43,22 @@ VECTOR_SIZE = 1536
 st.set_page_config(page_title="Huddle Assistant", layout="centered")
 
 # ---- HEADER ----
-st.markdown("""
-    <div style="
-        background: linear-gradient(135deg, #8a3ffc, #b88cff);
-        padding: 20px; border-radius: 12px; color: white;
-        text-align: center; font-family: 'Segoe UI', sans-serif;
-        margin-bottom: 24px;">
-        <h2 style="margin: 0;">🤝 Huddle Assistant</h2>
-        <p style="margin: 4px 0 0 0; font-size: 14px;">
-            Lead confident convos on the go
-        </p>
+with open("styles.css") as f:
+    st.markdown(f"<style>{f.read()}</style>", unsafe_allow_html=True)
+
+st.markdown(
+    """
+    <div class="header-container">
+        <h2>🤝 Huddle Assistant</h2>
+        <p>Lead confident convos on the go</p>
     </div>
-""", unsafe_allow_html=True)
+    """,
+    unsafe_allow_html=True,
+)
 
 # ---- Session State Initialization ----
 if "uploader_key" not in st.session_state:
     st.session_state.uploader_key = 0
-
-# ---- CSS for Spacing & Tabs ----
-st.markdown("""
-<style>
-section.main > div {padding-top: 0rem !important; padding-bottom: 0rem !important;}
-.css-1kyxreq, .stSelectbox, .stMarkdown, .stSubheader {margin-bottom: 0.5rem !important; margin-top: 0.5rem !important;}
-.st-expander {margin-top: -0.5rem !important;}
-.stTabs [data-baseweb="tab-list"] {
-    gap: 0.5rem !important; background: none !important;
-    border-bottom: 2px solid #27273a !important; margin-bottom: 0px !important;
-    padding: 0 6vw !important; justify-content: left;
-}
-.stTabs [data-baseweb="tab"] {
-    color: #8a3ffc !important; font-weight: 600; font-size: 1.05rem;
-    padding: 8px 16px !important; border-radius: 16px 16px 0 0;
-    background: none !important; transition: background 0.18s;
-    margin-bottom: -2px;
-}
-.stTabs [aria-selected="true"] {
-    background: linear-gradient(90deg, #8a3ffc 65%, #b88cff 100%) !important;
-    color: #fff !important; border-bottom: 2.5px solid #8a3ffc !important;
-    box-shadow: 0 2px 8px rgba(138,63,252,0.08);
-}
-.stTabs [aria-selected="false"]:hover {
-    background: #ede9fe !important; color: #5d27c1 !important;
-}
-</style>
-""", unsafe_allow_html=True)
 
 # ---- Sidebar Settings ----
 with st.sidebar.expander("🛠️ Quality Save Settings", expanded=False):
@@ -168,41 +140,28 @@ def render_polished_card(label, text_content, auto_copy=True): # Default auto_co
     # 4. HTML for the button and alert
     copy_button_html_structure = f"""
         <button id="{unique_button_id}"
-                title="Copy to clipboard"
-                style="float: right; background: #444; color: white; border: none; 
-                       padding: 6px 10px; border-radius: 6px; cursor: pointer;
-                       font-size: 14px; line-height: 1;">
+                title="Copy to clipboard" class="copy-button">
             📋 Copy
         </button>
-        <span id="{unique_alert_id}" 
-              style="display:none; float: right; margin-right: 8px; color: #90ee90; 
-                     font-size: 13px; line-height: 1; padding-top: 7px;">
+        <span id="{unique_alert_id}" class="copy-alert">
             Copied!
         </span>
     """
 
     # 5. Main card HTML structure
-    st.markdown(f"""
-    <style>
-    .card-header-h4 {{
-        margin-bottom: 12px;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-    }}
-    .card-header-h4 > span:first-of-type {{ margin-right: auto; }}
-    .card-header-h4 > div.button-container {{ display: flex; align-items: center; }}
-    </style>
-
-    <div style="border-radius: 16px; padding: 20px; background-color: #1e1e1e; color: white; font-size: 16px; line-height: 1.6; box-shadow: 0 0 8px rgba(255,255,255,0.05);">
+    st.markdown(
+        f"""
+    <div class="custom-card">
         <div class="card-header-h4">
             <span>✉️ {label}</span>
             <div class="button-container">{copy_button_html_structure}</div>
         </div>
-        <div style="clear: both;"></div>
+        <div class="clear-both"></div>
         <div>{safe_html_text_for_display}</div>
     </div>
-    """, unsafe_allow_html=True)
+    """,
+        unsafe_allow_html=True,
+    )
 
     # 6. JavaScript for functionality, run via components.html
     script_to_run = f"""
@@ -513,8 +472,8 @@ with tab1:
         # ---- Draft UI ----
         # (This section remains the same as your provided code)
         st.markdown(
-            """<p style='margin-bottom: 4px; font-size: 1em; color: inherit; font-weight: normal; padding: 0; line-height: 1.5;'>Your Draft Message</p>""", 
-            unsafe_allow_html=True
+            """<p class='draft-message-label'>Your Draft Message</p>""",
+            unsafe_allow_html=True,
         )
         st.session_state.user_draft_current = st.text_area(
             "Internal draft message label for accessibility", 
@@ -853,8 +812,14 @@ def save_human_override(story_text, image_url_provided, ai_message, human_messag
 # ------------- TAB 2: STORY INTERRUPTION GENERATOR --------------
 
 with tab2:
-    st.markdown('<div style="text-align:center;"><h4>📸 Story Interruption Generator</h4></div>', unsafe_allow_html=True)
-    st.markdown('<div style="text-align:center;"><span style="font-size:15px; color:#ccc;">Upload an Instagram story. The Huddle bot will suggest 3 warm, curious, and authentic replies based on the content.</span></div>', unsafe_allow_html=True)
+    st.markdown(
+        "<div class='center-text'><h4>📸 Story Interruption Generator</h4></div>",
+        unsafe_allow_html=True,
+    )
+    st.markdown(
+        "<div class='center-text'><span class='story-desc'>Upload an Instagram story. The Huddle bot will suggest 3 warm, curious, and authentic replies based on the content.</span></div>",
+        unsafe_allow_html=True,
+    )
 
     if "uploader_key_tab2" not in st.session_state:
         st.session_state.uploader_key_tab2 = 0

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,164 @@
+/* Huddle Assistant styles */
+
+.header-container {
+    background: linear-gradient(135deg, #8a3ffc, #b88cff);
+    padding: 20px;
+    border-radius: 12px;
+    color: white;
+    text-align: center;
+    font-family: 'Segoe UI', sans-serif;
+    margin-bottom: 24px;
+}
+.header-container h2 {
+    margin: 0;
+}
+.header-container p {
+    margin: 4px 0 0 0;
+    font-size: 14px;
+}
+
+/* Layout tweaks */
+section.main > div {
+    padding-top: 0rem !important;
+    padding-bottom: 0rem !important;
+}
+.css-1kyxreq, .stSelectbox, .stMarkdown, .stSubheader {
+    margin-bottom: 0.5rem !important;
+    margin-top: 0.5rem !important;
+}
+.st-expander {
+    margin-top: -0.5rem !important;
+}
+.stTabs [data-baseweb="tab-list"] {
+    gap: 0.5rem !important;
+    background: none !important;
+    border-bottom: 2px solid #27273a !important;
+    margin-bottom: 0px !important;
+    padding: 0 6vw !important;
+    justify-content: left;
+}
+.stTabs [data-baseweb="tab"] {
+    color: #8a3ffc !important;
+    font-weight: 600;
+    font-size: 1.05rem;
+    padding: 8px 16px !important;
+    border-radius: 16px 16px 0 0;
+    background: none !important;
+    transition: background 0.18s;
+    margin-bottom: -2px;
+}
+.stTabs [aria-selected="true"] {
+    background: linear-gradient(90deg, #8a3ffc 65%, #b88cff 100%) !important;
+    color: #fff !important;
+    border-bottom: 2.5px solid #8a3ffc !important;
+    box-shadow: 0 2px 8px rgba(138,63,252,0.08);
+}
+.stTabs [aria-selected="false"]:hover {
+    background: #ede9fe !important;
+    color: #5d27c1 !important;
+}
+
+/* Card styles */
+.custom-card {
+    border-radius: 16px;
+    padding: 20px;
+    background-color: #1e1e1e;
+    color: white;
+    font-size: 16px;
+    line-height: 1.6;
+    box-shadow: 0 0 8px rgba(255,255,255,0.05);
+}
+.card-header-h4 {
+    margin-bottom: 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.card-header-h4 > span:first-of-type {
+    margin-right: auto;
+}
+.card-header-h4 > div.button-container {
+    display: flex;
+    align-items: center;
+}
+
+.copy-button {
+    float: right;
+    background: #444;
+    color: white;
+    border: none;
+    padding: 6px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+}
+.copy-alert {
+    display: none;
+    float: right;
+    margin-right: 8px;
+    color: #90ee90;
+    font-size: 13px;
+    line-height: 1;
+    padding-top: 7px;
+}
+
+.center-text {
+    text-align: center;
+}
+.story-desc {
+    font-size: 15px;
+    color: #ccc;
+}
+
+.copy-card {
+    max-width: 100vw;
+    background-color: #1e1e1e;
+    border: 1px solid #333;
+    border-radius: 12px;
+    box-shadow: 0 20px 6px rgba(0,0,0,0.1);
+    padding: 16px;
+    margin: 0;
+    font-family: 'Segoe UI', sans-serif;
+    font-size: 16px;
+    color: #f0f0f0;
+}
+.copy-card h4 {
+    margin: 0 0 12px 0;
+}
+.text-display {
+    background: #2a2a2a;
+    border-radius: 8px;
+    padding: 12px;
+    white-space: normal;
+    word-wrap: break-word;
+    line-height: 1.6;
+    border: 1px solid #444;
+    overflow-y: auto;
+}
+
+.draft-message-label {
+    margin-bottom: 4px;
+    font-size: 1em;
+    color: inherit;
+    font-weight: normal;
+    padding: 0;
+    line-height: 1.5;
+}
+.clear-both { clear: both; }
+.copy-button-green {
+    margin-top: 12px;
+    padding: 6px 12px;
+    background-color: #22c55e;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-weight: 500;
+    cursor: pointer;
+}
+.copy-alert-green {
+    display: none;
+    margin-left: 10px;
+    color: #22c55e;
+    font-weight: 500;
+}


### PR DESCRIPTION
## Summary
- centralize styling into `styles.css`
- load stylesheet in both `app.py` and `app copy.py`
- convert inline styles to CSS classes

## Testing
- `python -m py_compile app.py 'app copy.py'`

------
https://chatgpt.com/codex/tasks/task_e_68419c73b4d4832e8dbdddcc92319ebc