### PR TITLE
Improve mobile layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,7 +40,7 @@ COLLECTION_NAME = "docs_memory" # For embedding general documents
 HUDDLE_MEMORY_COLLECTION = "huddle_memory" # For past huddles
 VECTOR_SIZE = 1536
 
-st.set_page_config(page_title="Huddle Assistant", layout="centered")
+st.set_page_config(page_title="Huddle Assistant", layout="wide")
 
 # ---- HEADER ----
 with open("styles.css") as f:
@@ -476,10 +476,11 @@ with tab1:
             unsafe_allow_html=True,
         )
         st.session_state.user_draft_current = st.text_area(
-            "Internal draft message label for accessibility", 
+            "Internal draft message label for accessibility",
             value=st.session_state.user_draft_current,
-            label_visibility="collapsed", height=110, 
-            key=st.session_state.user_draft_widget_key 
+            placeholder="Write your message here...",
+            label_visibility="collapsed", height=110,
+            key=st.session_state.user_draft_widget_key
         )
         
         # ---- Action Buttons ----

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,7 @@
 }
 .header-container h2 {
     margin: 0;
+    font-size: 1.8rem;
 }
 .header-container p {
     margin: 4px 0 0 0;
@@ -145,6 +146,9 @@ section.main > div {
     padding: 0;
     line-height: 1.5;
 }
+.stTextArea textarea {
+    font-size: 1rem;
+}
 .clear-both { clear: both; }
 .copy-button-green {
     margin-top: 12px;
@@ -161,4 +165,28 @@ section.main > div {
     margin-left: 10px;
     color: #22c55e;
     font-weight: 500;
+}
+
+@media (max-width: 480px) {
+    .header-container {
+        padding: 16px;
+    }
+    .header-container h2 {
+        font-size: 1.5rem;
+    }
+    .header-container p {
+        font-size: 13px;
+    }
+    .stTabs [data-baseweb="tab-list"] {
+        padding: 0 3vw !important;
+        overflow-x: auto;
+    }
+    .stTabs [data-baseweb="tab"] {
+        padding: 6px 12px !important;
+        font-size: 0.9rem;
+    }
+    .custom-card {
+        padding: 16px;
+        font-size: 15px;
+    }
 }


### PR DESCRIPTION
## Summary
- set Streamlit layout to wide
- add text area placeholder
- tweak fonts and responsive CSS for mobile screens

## Testing
- `python -m py_compile $(find . -name '*.py' -print0 | tr '\0' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_68419ed05dc8832eaacab74bbc1c408f