### PR TITLE
Add overlay effect to header intro animation

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,12 +48,26 @@ with open("styles.css") as f:
 
 st.markdown(
     """
-    <div class="header-container">
+    <div class="header-container animate-header">
         <h2>🤝 Huddle Assistant</h2>
         <p>Lead confident convos on the go</p>
     </div>
     """,
     unsafe_allow_html=True,
+)
+
+components.html(
+    """
+    <script>
+        const header = document.querySelector('.animate-header');
+        if (header) {
+            header.addEventListener('animationend', () => {
+                header.classList.remove('animate-header');
+            });
+        }
+    </script>
+    """,
+    height=0,
 )
 
 # ---- Session State Initialization ----

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,28 @@
     font-family: 'Segoe UI', sans-serif;
     margin-bottom: 24px;
 }
+
+/* Intro animation for the header */
+.animate-header {
+    position: relative;
+    z-index: 10000;
+    animation: header-intro 1.6s ease-out forwards;
+    transform-origin: center top;
+}
+
+@keyframes header-intro {
+    0% {
+        transform: scale(15);
+        opacity: 0;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
 .header-container h2 {
     margin: 0;
     font-size: 1.8rem;


### PR DESCRIPTION
## Summary
- ensure header animation overlays all content
- drop animation scale from 15× to normal size
- remove animation class after completion

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841a20957fc832e86fda8ff4339885e